### PR TITLE
Update README to add proguard rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ dependencies {
 }
 ```
 
+### Proguard
+
+Proguard users may need to add the following rule:
+
+```
+-keep class io.mavsdk.** { *; }
+```
+
 ## Contributing
 
 ### Coding style

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ dependencies {
 }
 ```
 
-### Proguard
+### ProGuard
 
-Proguard users may need to add the following rule:
+ProGuard users may need to add the following rule:
 
 ```
 -keep class io.mavsdk.** { *; }


### PR DESCRIPTION
If users want to enable code shrinking, obfuscation and optimization using ProGuard they can add this rule to the ProGuard file of their project. ProGuard removes some fields from mavsdk classes and native code present in the mavsdk-server module when the rule is not used.

This rule works for both mavsdk and mavsdk-server modules.

Tested on Android Studio 4.2 with Gradle 7.0.2