### PR TITLE
Implemented translate to rpc method in enums with constant-specific method implementations

### DIFF
--- a/sdk/templates/enum.j2
+++ b/sdk/templates/enum.j2
@@ -1,17 +1,12 @@
 public enum {{ name.upper_camel_case }} {
   {% for value in values %}
-  {{ value.name.uppercase }}{{ ", " if not loop.last }}
-  {%- endfor %};
-
-  protected {{ plugin_name.upper_camel_case }}Proto.{% if parent_struct is not none %}{{ parent_struct.upper_camel_case }}.{% endif %}{{ name.upper_camel_case }} rpc{{ name.upper_camel_case }}() {
-    switch (this) {
-      {% for value in values %}
-      case {{ value.name.uppercase }}:
-      {{ "default: " if loop.first }}
-        return {{ plugin_name.upper_camel_case}}Proto.{% if parent_struct is not none %}{{ parent_struct.upper_camel_case }}.{% endif %}{{ name.upper_camel_case }}.{{ name.uppercase }}_{{ value.name.uppercase }};
-      {%- endfor %}
+  {{ value.name.uppercase }} {
+    @Override
+    protected {{ plugin_name.upper_camel_case }}Proto.{% if parent_struct is not none %}{{ parent_struct.upper_camel_case }}.{% endif %}{{ name.upper_camel_case }} rpc{{ name.upper_camel_case }}() {
+      return {{ plugin_name.upper_camel_case}}Proto.{% if parent_struct is not none %}{{ parent_struct.upper_camel_case }}.{% endif %}{{ name.upper_camel_case }}.{{ name.uppercase }}_{{ value.name.uppercase }};
     }
-  }
+  }{{ ", " if not loop.last }}
+  {%- endfor %};
 
   protected static {{ name.upper_camel_case }} translateFromRpc({{ plugin_name.upper_camel_case }}Proto.{% if parent_struct is not none %}{{ parent_struct.upper_camel_case }}.{% endif %}{{ name.upper_camel_case }} rpc{{ name.upper_camel_case }}) {
     switch (rpc{{ name.upper_camel_case }}) {
@@ -22,4 +17,6 @@ public enum {{ name.upper_camel_case }} {
       {%- endfor -%}
     }
   }
+
+  protected abstract {{ plugin_name.upper_camel_case }}Proto.{% if parent_struct is not none %}{{ parent_struct.upper_camel_case }}.{% endif %}{{ name.upper_camel_case }} rpc{{ name.upper_camel_case }}();
 }


### PR DESCRIPTION
The translate to rpc methods in enums used to switch on their own values, which is fragile implementation. (Refer: Effective Java Vol 2: Item 30: Enum type that switches on its own value - questionable)

Therefore the enum template has been edited to generate methods that use constant-specific method implementation. (Refer: Effective Java Vol 2: Item 30: Enum type with constant-specific method implementations)

For example, this generates enums that are as follows:
```
public enum VideoStreamStatus {
          
  NOT_RUNNING {
    @Override
    protected CameraProto.VideoStreamInfo.VideoStreamStatus rpcVideoStreamStatus() {
       return CameraProto.VideoStreamInfo.VideoStreamStatus.VIDEO_STREAM_STATUS_NOT_RUNNING;
    }
  }, 
  IN_PROGRESS {
    @Override
    protected CameraProto.VideoStreamInfo.VideoStreamStatus rpcVideoStreamStatus() {
      return CameraProto.VideoStreamInfo.VideoStreamStatus.VIDEO_STREAM_STATUS_IN_PROGRESS;
    }
  };

  protected static VideoStreamStatus translateFromRpc(CameraProto.VideoStreamInfo.VideoStreamStatus rpcVideoStreamStatus) {
    switch (rpcVideoStreamStatus) {
      case VIDEO_STREAM_STATUS_NOT_RUNNING:
      default: 
        return VideoStreamStatus.NOT_RUNNING;
      case VIDEO_STREAM_STATUS_IN_PROGRESS:
              
        return VideoStreamStatus.IN_PROGRESS;}
  }

  protected abstract CameraProto.VideoStreamInfo.VideoStreamStatus rpcVideoStreamStatus();
}
```

The behaviour at the call site will be exactly the same as before. But there are certain benefits to it:

1. The enums hold a strong reference to their own translation functions, therefore the checks due to branching (switch) are not required.
2. The redundant `default` branch is not present.
3. Since `default` is removed, any mismatch will be caught at compile-time and those bugs won't propagate to run-time.