### PR TITLE
Template improvements involving addition of @CheckReturnValue and @NonNull

### DIFF
--- a/sdk/templates/call.j2
+++ b/sdk/templates/call.j2
@@ -1,5 +1,5 @@
 @CheckReturnValue
-public Completable {{ name.lower_camel_case }}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %}) {
+public Completable {{ name.lower_camel_case }}({% for param in params %}@NonNull {{ param.type_info.name }} {{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %}) {
   {{ plugin_name.upper_camel_case }}Proto.{{ name.upper_camel_case }}Request request = {{ plugin_name.upper_camel_case }}Proto.{{ name.upper_camel_case }}Request
           .newBuilder()
           {%- for param in params %}

--- a/sdk/templates/call.j2
+++ b/sdk/templates/call.j2
@@ -1,3 +1,4 @@
+@CheckReturnValue
 public Completable {{ name.lower_camel_case }}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %}) {
   {{ plugin_name.upper_camel_case }}Proto.{{ name.upper_camel_case }}Request request = {{ plugin_name.upper_camel_case }}Proto.{{ name.upper_camel_case }}Request
           .newBuilder()

--- a/sdk/templates/file.j2
+++ b/sdk/templates/file.j2
@@ -9,6 +9,7 @@ import io.reactivex.Flowable;
 import io.reactivex.Scheduler;
 import io.reactivex.Single;
 import io.reactivex.annotations.CheckReturnValue;
+import io.reactivex.annotations.NonNull;
 import io.reactivex.schedulers.Schedulers;
 import java.lang.String;
 import java.util.List;

--- a/sdk/templates/file.j2
+++ b/sdk/templates/file.j2
@@ -8,6 +8,7 @@ import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
 import io.reactivex.Scheduler;
 import io.reactivex.Single;
+import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.schedulers.Schedulers;
 import java.lang.String;
 import java.util.List;

--- a/sdk/templates/request.j2
+++ b/sdk/templates/request.j2
@@ -1,3 +1,4 @@
+@CheckReturnValue
 public Single<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}.{{ return_type.name }}{% endif %}> {{ name.lower_camel_case }}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %}) {
   {{ plugin_name.upper_camel_case }}Proto.{{ name.upper_camel_case }}Request request = {{ plugin_name.upper_camel_case }}Proto.{{ name.upper_camel_case }}Request
           .newBuilder()

--- a/sdk/templates/request.j2
+++ b/sdk/templates/request.j2
@@ -1,5 +1,5 @@
 @CheckReturnValue
-public Single<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}.{{ return_type.name }}{% endif %}> {{ name.lower_camel_case }}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %}) {
+public Single<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}.{{ return_type.name }}{% endif %}> {{ name.lower_camel_case }}({% for param in params %}@NonNull {{ param.type_info.name }} {{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %}) {
   {{ plugin_name.upper_camel_case }}Proto.{{ name.upper_camel_case }}Request request = {{ plugin_name.upper_camel_case }}Proto.{{ name.upper_camel_case }}Request
           .newBuilder()
           {%- for param in params %}

--- a/sdk/templates/stream.j2
+++ b/sdk/templates/stream.j2
@@ -83,6 +83,7 @@ private Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif 
   return flowable;
 }
 
+@CheckReturnValue
 public Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}.{{ return_type.name }}{% endif %}> get{{ name.upper_camel_case }}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %}) {
   {% if params|length > 0 %}
   return create{{ name.upper_camel_case }}({% for param in params %}{{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %});

--- a/sdk/templates/stream.j2
+++ b/sdk/templates/stream.j2
@@ -84,7 +84,7 @@ private Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif 
 }
 
 @CheckReturnValue
-public Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}.{{ return_type.name }}{% endif %}> get{{ name.upper_camel_case }}({% for param in params %}{{ param.type_info.name }} {{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %}) {
+public Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}.{{ return_type.name }}{% endif %}> get{{ name.upper_camel_case }}({% for param in params %}@NonNull {{ param.type_info.name }} {{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %}) {
   {% if params|length > 0 %}
   return create{{ name.upper_camel_case }}({% for param in params %}{{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %});
   {% else %}


### PR DESCRIPTION
1. `@CheckReturnValue` annotation marks methods whose return values should be checked. This is required because it informs the IDEs to throw a warning in case the return value is not used. For example, the users may use the methods and forget to subscribe to the RxJava objects:

```
system.getAction().setTakeoffAltitude(20);
```

Which should instead be:

```
Disposable d = system.getAction()
  .setTakeoffAltitude(20)
  .subscribe(onComplete, onError);
```

In the first commit, `@CheckReturnValue` has been added to the public methods that return a `Completable`, a `Flowable` or a `Single`.

2. When `null` is passed for the `@NonNull` annotated parameter, the IDE throws a warning in the case of Java and it's a compile-time error when called from Kotlin.

In the second commit, parameters of public methods have been annotated with `NonNull`. Though I had gone through the code on the gRPC side and found that the methods were null-intolerant, please let me know in case MAVSDK-Java actually expects null at someplace.