### PR TITLE
Streams fix

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -195,7 +195,7 @@ subprojects {
         implementation "io.grpc:grpc-stub:${grpcVersion}"
         implementation 'org.slf4j:slf4j-api:1.7.25'
         api 'com.google.protobuf:protobuf-lite:3.0.1'
-        api 'io.reactivex.rxjava2:rxjava:2.1.7'
+        api 'io.reactivex.rxjava2:rxjava:2.2.21'
 
         compileOnly "javax.annotation:javax.annotation-api:1.3.2"
 

--- a/sdk/templates/stream.j2
+++ b/sdk/templates/stream.j2
@@ -80,7 +80,7 @@ private Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif 
       });
     }, BackpressureStrategy.BUFFER);
 
-  return flowable;
+  return flowable.share();
 }
 
 @CheckReturnValue


### PR DESCRIPTION
Problem: If two subscribers subscribed to the same flowable, the one which subscribed first would stop getting emissions.

Fix: Added `Flowable#share` operator that allows multiple subscribers to get the emissions simultaneously.