### PR TITLE
Fix finite streams

### DIFF
--- a/sdk/templates/stream.j2
+++ b/sdk/templates/stream.j2
@@ -131,7 +131,7 @@ private Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif 
 }
 
 @CheckReturnValue
-public Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}.{{ return_type.name }}{% endif %}> get{{ name.upper_camel_case }}({% for param in params %}@NonNull {{ param.type_info.name }} {{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %}) {
+public Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}.{{ return_type.name }}{% endif %}> {{ name.lower_camel_case }}({% for param in params %}@NonNull {{ param.type_info.name }} {{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %}) {
   return create{{ name.upper_camel_case }}({% for param in params %}{{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %});
 }
 

--- a/sdk/templates/stream.j2
+++ b/sdk/templates/stream.j2
@@ -1,4 +1,4 @@
-{% if params|length == 0 %}
+{% if not is_finite %}
 // Infinite stream
 private final FlowableProcessor<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}.{{ return_type.name }}{% endif %}> {{ name.lower_camel_case }}Processor = PublishProcessor.create();
 private final Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}.{{ return_type.name }}{% endif %}> {{ name.lower_camel_case }} = {{ name.lower_camel_case }}Processor.onBackpressureBuffer().share();;

--- a/sdk/templates/stream.j2
+++ b/sdk/templates/stream.j2
@@ -4,7 +4,7 @@ private final FlowableProcessor<{% if return_type.is_primitive %}{{ return_type.
 private final Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}.{{ return_type.name }}{% endif %}> {{ name.lower_camel_case }} = {{ name.lower_camel_case }}Processor.onBackpressureBuffer().share();;
 private volatile boolean is{{ name.upper_camel_case }}Initialized = false;
 
-private void process{{ name.upper_camel_case }}() {
+private void process{{ name.upper_camel_case }}({% for param in params %}@NonNull {{ param.type_info.name }} {{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %}) {
   {{ plugin_name.upper_camel_case }}Proto.Subscribe{{ name.upper_camel_case }}Request request = {{ plugin_name.upper_camel_case }}Proto.Subscribe{{ name.upper_camel_case }}Request.newBuilder()
     {%- for param in params %}
       {%- if param.type_info.is_primitive %}
@@ -49,11 +49,11 @@ private void process{{ name.upper_camel_case }}() {
 }
 
 @CheckReturnValue
-public Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}.{{ return_type.name }}{% endif %}> get{{ name.upper_camel_case }}() {
+public Flowable<{% if return_type.is_primitive %}{{ return_type.name }}{% elif return_type.is_repeated %}List<{{ plugin_name.upper_camel_case }}.{{ return_type.inner_name }}>{% else %}{{ plugin_name.upper_camel_case }}.{{ return_type.name }}{% endif %}> get{{ name.upper_camel_case }}({% for param in params %}@NonNull {{ param.type_info.name }} {{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %}) {
   if (!is{{ name.upper_camel_case }}Initialized) {
     synchronized (this) {
       if (!is{{ name.upper_camel_case }}Initialized) {
-        MavsdkEventQueue.executor().execute(() -> process{{ name.upper_camel_case }}());
+        MavsdkEventQueue.executor().execute(() -> process{{ name.upper_camel_case }}({% for param in params %}{{ param.name.lower_camel_case }}{{ ", " if not loop.last }}{% endfor %}));
         is{{ name.upper_camel_case }}Initialized = true;
       }
     }


### PR DESCRIPTION
Earlier `if params|length == 0` was used to check if the stream was a finite (command along with associated progress data) or an infinite (simple data stream eg. position updates) one.

This was correct for most cases except for calibration methods (there could be more). Therefore, the old logic is replaced by a simple [is_finite](https://github.com/mavlink/MAVSDK-Proto/blob/4446fa10dc52876206108ac22548529088c91f98/pb_plugins/protoc_gen_mavsdk/methods.py#L298) check.