### PR TITLE
Update ndk to 25.1.8937393

### DIFF
--- a/mavsdk_server/build.gradle
+++ b/mavsdk_server/build.gradle
@@ -143,5 +143,5 @@ android {
         }
     }
 
-    ndkVersion "23.1.7779620"
+    ndkVersion "25.1.8937393"
 }


### PR DESCRIPTION
Maybe fixes https://github.com/mavlink/MAVSDK-Java/issues/115

@divyanshu1234 would you mind trying with this change? You may have to install the new NDK from the SDK Manager. I'm hoping that this will come with the newer libc++, which will have our missing symbol.