### PR TITLE
Update `mavsdk_server_release` from `v2.1.0` to `v2.12.2`

### DIFF
--- a/mavsdk_server/build.gradle
+++ b/mavsdk_server/build.gradle
@@ -19,7 +19,7 @@ allprojects {
         mavenCentral()
     }
 
-    def mavsdk_server_release = "v2.1.0"
+    def mavsdk_server_release = "v2.12.2"
 
     task extractMavsdkServer(type: Copy) {
         mkdir project.buildDir.getAbsolutePath() + "/tmp"

--- a/mavsdk_server/build.gradle
+++ b/mavsdk_server/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.2.2'
     }
 }
 

--- a/mavsdk_server/build.gradle
+++ b/mavsdk_server/build.gradle
@@ -124,7 +124,7 @@ android {
         archivesBaseName = 'mavsdk-server'
         group = 'io.mavsdk'
         versionCode 2
-        version '2.0.0'
+        version '2.0.1'
 
         ndk {
             abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'


### PR DESCRIPTION
In summary, MAVSDK-Java didn't reflect the latest version for it's `mavsdk_server` dependency. This PR does this manually (or at least, it will try).

The entire context and inspiration for this PR in this [issue here](https://github.com/mavlink/MAVSDK-Java/issues/166).

Personally, I'd love if this version number could somehow be dynamically set or something... Like a pipeline thing, or such, what do you think? Something like this should be possible, right?