### PR TITLE
Set a default temporary folder for MavsdkServer

### DIFF
--- a/mavsdk_server/src/main/java/io/mavsdk/mavsdkserver/MavsdkServer.java
+++ b/mavsdk_server/src/main/java/io/mavsdk/mavsdkserver/MavsdkServer.java
@@ -1,9 +1,20 @@
 package io.mavsdk.mavsdkserver;
 
+import android.content.Context;
+
 public class MavsdkServer {
 
   static {
     java.lang.System.loadLibrary("native_lib");
+  }
+
+  public MavsdkServer(Context context) {
+    String cacheDir = context.getCacheDir().getAbsolutePath();
+    setTempDirectory(cacheDir);
+  }
+
+  public MavsdkServer(String tempDirectory) {
+    setTempDirectory(tempDirectory);
   }
 
   private long mavsdkServerHandle;


### PR DESCRIPTION
We either need a context to create a temporary dir, or ask the user to give us a path. 

Resolves #217.